### PR TITLE
Remove protobuf php ext

### DIFF
--- a/cli/alpine.Dockerfile
+++ b/cli/alpine.Dockerfile
@@ -14,7 +14,6 @@ RUN set -xe \
     && docker-php-ext-install bcmath pdo_pgsql pdo_mysql soap zip
 
 RUN pecl install grpc && docker-php-ext-enable grpc \
-    && pecl install protobuf && docker-php-ext-enable protobuf \
     && pecl install redis && docker-php-ext-enable redis
 
 # Build, install and enable PHP rdkafka extension

--- a/cli/debian.Dockerfile
+++ b/cli/debian.Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
     && docker-php-ext-install zip soap bcmath pgsql pdo_pgsql pdo_mysql
 
 RUN pecl install grpc && docker-php-ext-enable grpc \
-    && pecl install protobuf && docker-php-ext-enable protobuf \
     && pecl install redis && docker-php-ext-enable redis
 
 #installing kafka

--- a/fpm/alpine.Dockerfile
+++ b/fpm/alpine.Dockerfile
@@ -14,7 +14,6 @@ RUN set -xe \
     && docker-php-ext-install bcmath pdo_pgsql pdo_mysql soap zip
 
 RUN pecl install grpc && docker-php-ext-enable grpc \
-    && pecl install protobuf && docker-php-ext-enable protobuf \
     && pecl install redis && docker-php-ext-enable redis
 
 # Build, install and enable PHP rdkafka extension

--- a/fpm/debian.Dockerfile
+++ b/fpm/debian.Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
     && docker-php-ext-install zip soap bcmath pgsql pdo_pgsql pdo_mysql
 
 RUN pecl install grpc && docker-php-ext-enable grpc \
-    && pecl install protobuf && docker-php-ext-enable protobuf \
     && pecl install redis && docker-php-ext-enable redis
 
 #installing kafka


### PR DESCRIPTION
This ext for the PHP7.3 is causing an error when we try to send a
document to firestore

Error: "Segmentation fault (core dumped)"