### PR TITLE
Adiciona extensão grpc ao dockerfile do apache

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -29,6 +29,8 @@ RUN ln -fs /usr/share/zoneinfo/${DEFAULT_TIMEZONE} /etc/localtime \
     && rm -rf /tmp/librdkafka \
 # Install some other PECL extensions
     && pecl install imagick && docker-php-ext-enable imagick \
+    && pecl install protobuf && docker-php-ext-enable protobuf \
+    && pecl install grpc && docker-php-ext-enable grpc \
     && pecl install ds && docker-php-ext-enable ds \
     && pecl install timezonedb \
 # Install othe PHP extensions and Filebeat


### PR DESCRIPTION
Hoje no monolith usamos a imagem com apache, mas nessa imagem não temos
a extensão do grpc.

Foi adicionado a extensão no dockerfile.