### PR TITLE
Adiciona suporte ao redis na imagem do monolito

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -32,6 +32,7 @@ RUN ln -fs /usr/share/zoneinfo/${DEFAULT_TIMEZONE} /etc/localtime \
     && pecl install protobuf && docker-php-ext-enable protobuf \
     && pecl install grpc && docker-php-ext-enable grpc \
     && pecl install ds && docker-php-ext-enable ds \
+    && pecl install redis && docker-php-ext-enable redis \
     && pecl install timezonedb \
 # Install othe PHP extensions and Filebeat
     && docker-php-ext-install zip pdo_pgsql pdo_mysql soap opcache xmlrpc xsl bcmath \


### PR DESCRIPTION
Precisamos acessar o redis na imagem base do monolito

Adicionamos a instrucao que instala o redis.

LINKS:
+JIRA https://arquivei.atlassian.net/browse/WALLSTREET-94