### PR TITLE
Adiciona extensão intl à imagem php:7.1-apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Docker PHP based on PHP:7.1
 ## Installed PHP Modules
 
 * gd
+* intl
 * mcrypt
 * opcache
 * pdo_pgsql

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -35,7 +35,7 @@ RUN ln -fs /usr/share/zoneinfo/${DEFAULT_TIMEZONE} /etc/localtime \
     && pecl install redis && docker-php-ext-enable redis \
     && pecl install timezonedb \
 # Install othe PHP extensions and Filebeat
-    && docker-php-ext-install zip pdo_pgsql pdo_mysql soap opcache xmlrpc xsl bcmath \
+    && docker-php-ext-install zip pdo_pgsql pdo_mysql soap opcache xmlrpc xsl bcmath intl \
     && docker-php-ext-configure gd --enable-gd-native-ttf --with-jpeg-dir=/usr/lib/x86_64-linux-gnu \
         --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu \
     && docker-php-ext-install gd


### PR DESCRIPTION
A extensão `intl` traz funcionalidades de normalização de strings que
são úteis para ajudar na limpeza e normalização de textos provenientes
de input do usuário.