### PR TITLE
Updates dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-php
 
-Docker PHP based on PHP:7.3
+Docker PHP based on PHP:7.4
 
 ## Installed Packages
 

--- a/cli/alpine.Dockerfile
+++ b/cli/alpine.Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 LABEL maintainer="Engenharia Arquivei <engenharia@arquivei.com.br>"
-ARG RDKAFKA_VERSION="1.1.0"
-ARG RDKAFKA_PECL_VERSION="3.1.2"
+ARG RDKAFKA_VERSION="1.5.3"
+ARG RDKAFKA_PECL_VERSION="4.0.4"
 
 RUN set -xe \
     && apk update \

--- a/cli/debian.Dockerfile
+++ b/cli/debian.Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.3-cli
+FROM php:7.4-cli
 
 LABEL maintainer="Engenharia Arquivei <engenharia@arquivei.com.br>"
-ARG RDKAFKA_VERSION="1.1.0"
-ARG RDKAFKA_PECL_VERSION="3.1.2"
+ARG RDKAFKA_VERSION="1.5.3"
+ARG RDKAFKA_PECL_VERSION="4.0.4"
 
 RUN apt-get update \
     && apt-get -y install git libzip-dev libxml2-dev unzip libpq-dev \

--- a/fpm/alpine.Dockerfile
+++ b/fpm/alpine.Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.3-fpm-alpine
+FROM php:7.4-fpm-alpine
 
 LABEL maintainer="Engenharia Arquivei <engenharia@arquivei.com.br>"
-ARG RDKAFKA_VERSION="1.1.0"
-ARG RDKAFKA_PECL_VERSION="3.1.2"
+ARG RDKAFKA_VERSION="1.5.3"
+ARG RDKAFKA_PECL_VERSION="4.0.4"
 
 RUN set -xe \
     && apk update \

--- a/fpm/debian.Dockerfile
+++ b/fpm/debian.Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 LABEL maintainer="Engenharia Arquivei <engenharia@arquivei.com.br>"
-ARG RDKAFKA_VERSION="1.1.0"
-ARG RDKAFKA_PECL_VERSION="3.1.2"
+ARG RDKAFKA_VERSION="1.5.3"
+ARG RDKAFKA_PECL_VERSION="4.0.4"
 
 RUN apt-get update \
     && apt-get -y install git libzip-dev libxml2-dev unzip libpq-dev \


### PR DESCRIPTION
* PHP was updated to 7.4 (some of our projects may have incompatibility
issues with PHP 8)
* rdkafka and ext-rdkafka were updated to latest version with which our
Kafka library has been tested. For the PECL extension, there are newer
versions available, but since they haven't been tested yet, updating to
them may not be safe.