### PR TITLE
Disable exposing php version

### DIFF
--- a/fpm/alpine.Dockerfile
+++ b/fpm/alpine.Dockerfile
@@ -30,3 +30,5 @@ RUN set -xe \
     && rm -rf /tmp/librdkafka \
 # Remove build dependencies. MUST BE LAST COMMAND!
     && apk del .build-deps
+
+RUN echo "expose_php=0" >  /usr/local/etc/php/conf.d/docker-php-arquivei.ini

--- a/fpm/debian.Dockerfile
+++ b/fpm/debian.Dockerfile
@@ -22,3 +22,5 @@ RUN apt-get update \
     && pecl install rdkafka-${RDKAFKA_PECL_VERSION} \
     && docker-php-ext-enable rdkafka \
     && rm -rf /tmp/librdkafka
+
+RUN echo "expose_php=0" >  /usr/local/etc/php/conf.d/docker-php-arquivei.ini


### PR DESCRIPTION
By exposing the PHP version publicly we may open a breach for attacks.

Add an ini directive to disable exposing the php version.